### PR TITLE
⬆️ Bump files with dotnet-file sync

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 # normalize by default
 * text=auto encoding=UTF-8
 *.sh text eol=lf
+*.sbn eol=lf
 
 # These are windows specific files which we may as well ensure are
 # always crlf on checkout

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ BenchmarkDotNet.Artifacts
 .genaiscript
 .idea
 local.settings.json
+.env
 
 *.suo
 *.sdf

--- a/.netconfig
+++ b/.netconfig
@@ -5,13 +5,13 @@
 	weak
 [file ".gitattributes"]
 	url = https://github.com/devlooped/oss/blob/main/.gitattributes
-	sha = 5f92a68e302bae675b394ef343114139c075993e
-	etag = 338ba6d92c8d1774363396739c2be4257bfc58026f4b0fe92cb0ae4460e1eff7
+	sha = 4a9aa321c4982b83c185cf8dffed181ff84667d5
+	etag = 09cad18280ed04b67f7f87591e5481510df04d44c3403231b8af885664d8fd58
 	weak
 [file ".gitignore"]
 	url = https://github.com/devlooped/oss/blob/main/.gitignore
-	sha = e0be248fff1d39133345283b8227372b36574b75
-	etag = c449ec6f76803e1891357ca2b8b4fcb5b2e5deeff8311622fd92ca9fbf1e6575
+	sha = 3776526342afb3f57da7e80f2095e5fdca3c31c9
+	etag = 11767f73556aa4c6c8bcc153b77ee8e8114f99fa3b885b0a7d66d082f91e77b3
 	weak
 [file ".github/workflows/dotnet-file.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/dotnet-file.yml


### PR DESCRIPTION
# devlooped/oss

- Ensure lf for Scriban templates always https://github.com/devlooped/oss/commit/4a9aa32
- Ignore .env files recursively https://github.com/devlooped/oss/commit/3776526